### PR TITLE
Fix the  CD for the releases so that it will successfully push to the docs branch

### DIFF
--- a/.github/workflows/cd_releases.yml
+++ b/.github/workflows/cd_releases.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read  #<-- to allow checkout of the repository
+      contents: write  #<-- to allow mike to push to the repository
 
     steps:
 
@@ -117,7 +117,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.13'
 
       - name: Install UV
         id: install-uv
@@ -134,12 +134,12 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B main --track origin/main
           git remote update
-          git fetch --prune
-          git fetch --prune --tags
+          git fetch --verbose
+          git fetch --verbose --tags
           git pull --verbose
           git status --verbose
           git branch --list --verbose


### PR DESCRIPTION
This pull request includes several changes to the continuous deployment workflow in the `.github/workflows/cd_releases.yml` file. The changes focus on updating permissions, specifying the Python version format, and modifying the Git configuration and fetch commands.

Key changes:

* Updated permissions to allow write access for pushing to the repository.
* Changed the format of the Python version to a string for compatibility.
* Modified Git configuration to use a bot's username and email.
* Updated Git fetch commands to use verbose mode for better logging.