### PR TITLE
Fix bug with the `hatchling` build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/data_science_extensions"]
+
 [project]
 name = "data-science-extensions"
 version = "0.1.0"


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change adds a new build target for the wheel package, specifying the `src/data_science_extensions` directory as the package location.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R5-R7): Added a new build target for the wheel package, specifying the `src/data_science_extensions` directory as the package location.