### PR TITLE
Fix bug in the CD Releases workflow

### DIFF
--- a/.github/workflows/cd_releases.yml
+++ b/.github/workflows/cd_releases.yml
@@ -168,6 +168,7 @@ jobs:
             git commit -m "Bump version to \`${CLEAN_VERSION}\` [skip ci]"
             git push origin main
             echo "Version bumped to ${CLEAN_VERSION}"
+          fi
 
       - name: Build Docs
         id: build-docs


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/cd_releases.yml` file. The change adds a missing `fi` statement to properly close the conditional block in the script. 

* [`.github/workflows/cd_releases.yml`](diffhunk://#diff-a4e92b3c95d263731fc187edd729ea1bd2b1621ec6b146f830ce3b52602c32b7R171): Added a missing `fi` statement to close the conditional block.