### PR TITLE
Fix docs deployment scripts

### DIFF
--- a/.github/workflows/cd_releases.yml
+++ b/.github/workflows/cd_releases.yml
@@ -179,5 +179,5 @@ jobs:
           git config --global --list
           git config --local --list
           git remote --verbose
-          uv run mike --debug deploy --update-aliases --branch=docs-site --push $(VERSION) latest
+          uv run mike --debug deploy --update-aliases --branch=docs-site --push ${VERSION} latest
           uv run mike --debug set-default --branch=docs-site --push latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 uv.lock
+web/

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,5 +1,5 @@
 site_name: Data Science Extensions
-site_description: Data Science Extensions
+site_description: The Data Science Extensions provides helpful utilities and extensions for data science projects.
 site_author: "[Chris Mahoney](mailto:chris@mahoneyconsultingservices.com)"
 site_dir: web
 docs_dir: docs

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -4,8 +4,8 @@ site_author: "[Chris Mahoney](mailto:chris@mahoneyconsultingservices.com)"
 site_dir: web
 docs_dir: docs
 remote_branch: docs-site
-repo_name: website
-repo_url: https://github.com/data-science-extensions/website
+repo_name: data-science-extensions
+repo_url: https://github.com/data-science-extensions/data-science-extensions
 edit_uri: edit/main/docs/
 
 watch:


### PR DESCRIPTION
This pull request includes changes to the deployment script and the site configuration for the Data Science Extensions project. The most important changes involve updating the deployment command to use an environment variable and enhancing the site description and repository information in the configuration file.

Deployment script update:

* [`.github/workflows/cd_releases.yml`](diffhunk://#diff-a4e92b3c95d263731fc187edd729ea1bd2b1621ec6b146f830ce3b52602c32b7L182-R182): Changed the deployment command to use `${VERSION}` instead of `$(VERSION)` for better compatibility with environment variables.

Site configuration enhancements:

* [`mkdocs.yaml`](diffhunk://#diff-57381c8acc17df6530456c578e76d03d4a1cb287f7edd980502b4a9cedb9524dL2-R8): Updated the `site_description` to provide a more detailed description of the project.
* [`mkdocs.yaml`](diffhunk://#diff-57381c8acc17df6530456c578e76d03d4a1cb287f7edd980502b4a9cedb9524dL2-R8): Changed `repo_name` and `repo_url` to accurately reflect the repository's new name and URL.