### PR TITLE
Enhance toolbox pages by hiding TOC sidebar

### DIFF
--- a/docs/toolboxes/toolbox-pyspark.md
+++ b/docs/toolboxes/toolbox-pyspark.md
@@ -2,9 +2,11 @@
 title: PySpark Toolbox
 subtitle: Helper files/functions/classes for generic PySpark processes
 icon: simple/apachespark
+hide:
+    - toc
 ---
 
-<div style="position: relative; width: 100%; height: 400px;">
+<div style="position: relative; width: 100%; height: 450px;">
     <iframe
         src="https://www.data-science-extensions.com/toolbox-pyspark"
         style="zoom: 70%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"

--- a/docs/toolboxes/toolbox-pyspark.md
+++ b/docs/toolboxes/toolbox-pyspark.md
@@ -6,10 +6,10 @@ hide:
     - toc
 ---
 
-<div style="position: relative; width: 100%; height: 450px;">
+<div style="position: relative; width: 100%; height: 500px;">
     <iframe
         src="https://www.data-science-extensions.com/toolbox-pyspark"
-        style="zoom: 70%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
+        style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
     >
     </iframe>
     <a

--- a/docs/toolboxes/toolbox-python.md
+++ b/docs/toolboxes/toolbox-python.md
@@ -6,10 +6,10 @@ hide:
     - toc
 ---
 
-<div style="position: relative; width: 100%; height: 450px;">
+<div style="position: relative; width: 100%; height: 500px;">
     <iframe
         src="https://www.data-science-extensions.com/toolbox-python"
-        style="zoom: 70%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
+        style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
     >
     </iframe>
     <a

--- a/docs/toolboxes/toolbox-python.md
+++ b/docs/toolboxes/toolbox-python.md
@@ -2,9 +2,11 @@
 title: Python Toolbox
 subtitle: Helper files/functions/classes for generic Python processes
 icon: simple/python
+hide:
+    - toc
 ---
 
-<div style="position: relative; width: 100%; height: 400px;">
+<div style="position: relative; width: 100%; height: 450px;">
     <iframe
         src="https://www.data-science-extensions.com/toolbox-python"
         style="zoom: 70%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"


### PR DESCRIPTION
This pull request includes updates to the documentation for the PySpark and Python toolboxes. The changes primarily focus on the layout and presentation of the content.

Presentation improvements:

* [`docs/toolboxes/toolbox-pyspark.md`](diffhunk://#diff-8e4869d7ccd1623b8376ac5c51f7b1c130e8172bbac69c667eece75ed9004a96R5-R12): Increased the iframe height from 400px to 500px and adjusted the zoom level from 70% to 90%. Additionally, the table of contents (toc) is now hidden.
* [`docs/toolboxes/toolbox-python.md`](diffhunk://#diff-973f0d61d945ee685ebdaae95a5a607c48d5871bad6b4d521c5b3a1ca522ad63R5-R12): Similar to the PySpark toolbox, the iframe height was increased from 400px to 500px, the zoom level was adjusted from 70% to 90%, and the table of contents (toc) is now hidden.