### PR TITLE
Enhance the `deploy_docs` workflow to add a process to deploy the sub-repos under a specific sub-directory

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -57,14 +57,14 @@ jobs:
           REPOS: ${{ vars.REPOS }}
         run: |
           # Debug
-          echo "REPOS: ${REPOS}"
+          echo -e "REPOS:\n${REPOS}"
 
           # Loop through each repo
           echo "${REPOS}" | while IFS= read -r line; do
 
             # Extract the variables
             echo "--> Extracting variables from line: ${line}"
-            read -r REPO BRANCH <<< "${line}"
+            read -r REPO BRANCH DIRECTORY <<< "${line}"
             REPO_NAME=$(basename -s .git "${REPO}")
             BRANCH=$(echo "${BRANCH}" | tr -d '\r' | tr -d '\n' | xargs)  # Trim any leading/trailing whitespace and remove carriage return and newline
 
@@ -73,8 +73,8 @@ jobs:
             git clone --single-branch --branch "${BRANCH}" "${REPO}" "/tmp/${REPO_NAME}"
 
             # Copy contents to the desired location in the current repo
-            echo "--> Copying files from '/tmp/${REPO_NAME}' to './${REPO_NAME}'"
-            cp --recursive --update "/tmp/${REPO_NAME}/." "./${REPO_NAME}"
+            echo "--> Copying files from '/tmp/${REPO_NAME}' to './${DIRECTORY}/${REPO_NAME}'"
+            cp --recursive --update "/tmp/${REPO_NAME}/." "./${DIRECTORY}/${REPO_NAME}"
 
             # Remove the temporary directory
             echo "--> Removing temporary directory '/tmp/${REPO_NAME}'"
@@ -82,10 +82,10 @@ jobs:
 
             # Add the changes to git
             echo "--> Adding changes to git"
-            git add "./${REPO_NAME}"
+            git add "./${DIRECTORY}/${REPO_NAME}"
 
             # Commit the changes
-            git commit -m "Updated files from \`${REPO_NAME}\` (branch: \`${BRANCH}\`) [skip ci]" || echo "--> No changes to commit"
+            git commit --message "Updated files from \`${REPO_NAME}\` (branch: \`${BRANCH}\`) [skip ci]" || echo "--> No changes to commit"
 
           done
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy_docs.yml` file to enhance the deployment process for documentation. The changes primarily involve adding support for specifying a target directory for each repository and improving debug output formatting.

### Workflow improvements:

* Updated the debug output to display repository information in a more readable format using `echo -e` for multiline output. (`[.github/workflows/deploy_docs.ymlL60-R67](diffhunk://#diff-03a7a8b3c4769e5bf1edd4a2edfa35190b649a71acf721c44d6b985e5a916719L60-R67)`)
* Modified the script to include a `DIRECTORY` variable when reading repository lines, allowing files to be copied into specified subdirectories instead of the root directory. (`[.github/workflows/deploy_docs.ymlL60-R67](diffhunk://#diff-03a7a8b3c4769e5bf1edd4a2edfa35190b649a71acf721c44d6b985e5a916719L60-R67)`)
* Adjusted file copy operations to target `./${DIRECTORY}/${REPO_NAME}` instead of `./${REPO_NAME}`, enabling more organized file placement. (`[.github/workflows/deploy_docs.ymlL76-R88](diffhunk://#diff-03a7a8b3c4769e5bf1edd4a2edfa35190b649a71acf721c44d6b985e5a916719L76-R88)`)
* Updated `git add` and `git commit` commands to reflect the new directory structure, ensuring changes are tracked and committed correctly. (`[.github/workflows/deploy_docs.ymlL76-R88](diffhunk://#diff-03a7a8b3c4769e5bf1edd4a2edfa35190b649a71acf721c44d6b985e5a916719L76-R88)`)