### PR TITLE
Add a step to the `deploy_docs` workflow to check if the target `DIRECTORY` exists or not

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -68,6 +68,14 @@ jobs:
             REPO_NAME=$(basename -s .git "${REPO}")
             BRANCH=$(echo "${BRANCH}" | tr -d '\r' | tr -d '\n' | xargs)  # Trim any leading/trailing whitespace and remove carriage return and newline
 
+            # Check if the directory exists, if not create it
+            if [ ! -d "./${DIRECTORY}" ]; then
+              echo "--> Creating directory './${DIRECTORY}'"
+              mkdir -p "./${DIRECTORY}"
+            else
+              echo "--> Directory './${DIRECTORY}' exists"
+            fi
+
             # Clone the repo to a temporary directory
             echo "--> Cloning branch '${BRANCH}' from '${REPO_NAME}': ${REPO}"
             git clone --single-branch --branch "${BRANCH}" "${REPO}" "/tmp/${REPO_NAME}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -71,7 +71,7 @@ jobs:
             # Check if the directory exists, if not create it
             if [ ! -d "./${DIRECTORY}" ]; then
               echo "--> Creating directory './${DIRECTORY}'"
-              mkdir -p "./${DIRECTORY}"
+              mkdir --parents "./${DIRECTORY}"
             else
               echo "--> Directory './${DIRECTORY}' exists"
             fi


### PR DESCRIPTION
This pull request introduces a small change to the `.github/workflows/deploy_docs.yml` file. It adds a check to ensure a specified directory exists before proceeding, creating the directory if it does not exist. This improves the workflow's robustness by preventing errors related to missing directories.