### PR TITLE
Clean up whitespace and new lines in `BRANCH` and `DIRECTORY` variables

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -66,7 +66,10 @@ jobs:
             echo "--> Extracting variables from line: ${line}"
             read -r REPO BRANCH DIRECTORY <<< "${line}"
             REPO_NAME=$(basename -s .git "${REPO}")
-            BRANCH=$(echo "${BRANCH}" | tr -d '\r' | tr -d '\n' | xargs)  # Trim any leading/trailing whitespace and remove carriage return and newline
+
+            # Clean up the variables to trim any leading/trailing whitespace and remove carriage return and newlines
+            BRANCH=$(echo "${BRANCH}" | tr -d '\r' | tr -d '\n' | xargs)
+            DIRECTORY=$(echo "${DIRECTORY}" | tr -d '\r' | tr -d '\n' | xargs)
 
             # Check if the directory exists, if not create it
             if [ ! -d "./${DIRECTORY}" ]; then


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/deploy_docs.yml` file to ensure that the `DIRECTORY` variable is cleaned up by trimming whitespace and removing carriage return and newline characters.