### PR TITLE
Update iframe and link sources in toolbox documentation to use the correct path

### DIFF
--- a/docs/toolboxes/synthetic-data-generators.md
+++ b/docs/toolboxes/synthetic-data-generators.md
@@ -8,12 +8,12 @@ hide:
 
 <div style="position: relative; width: 100%; height: 500px;">
     <iframe
-        src="https://www.data-science-extensions.com/synthetic-data-generators"
+        src="https://www.data-science-extensions.com/toolboxes/synthetic-data-generators"
         style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
     >
     </iframe>
     <a
-        href="https://www.data-science-extensions.com/synthetic-data-generators"
+        href="https://www.data-science-extensions.com/toolboxes/synthetic-data-generators"
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; display: block;"
     ></a>
 </div>

--- a/docs/toolboxes/toolbox-pyspark.md
+++ b/docs/toolboxes/toolbox-pyspark.md
@@ -8,12 +8,12 @@ hide:
 
 <div style="position: relative; width: 100%; height: 500px;">
     <iframe
-        src="https://www.data-science-extensions.com/toolbox-pyspark"
+        src="https://www.data-science-extensions.com/toolboxes/toolbox-pyspark"
         style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
     >
     </iframe>
     <a
-        href="https://www.data-science-extensions.com/toolbox-pyspark"
+        href="https://www.data-science-extensions.com/toolboxes/toolbox-pyspark"
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; display: block;"
     ></a>
 </div>

--- a/docs/toolboxes/toolbox-python.md
+++ b/docs/toolboxes/toolbox-python.md
@@ -8,12 +8,12 @@ hide:
 
 <div style="position: relative; width: 100%; height: 500px;">
     <iframe
-        src="https://www.data-science-extensions.com/toolbox-python"
+        src="https://www.data-science-extensions.com/toolboxes/toolbox-python"
         style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
     >
     </iframe>
     <a
-        href="https://www.data-science-extensions.com/toolbox-python"
+        href="https://www.data-science-extensions.com/toolboxes/toolbox-python"
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; display: block;"
     ></a>
 </div>


### PR DESCRIPTION
This pull request updates the URLs in multiple documentation files to reflect the new directory structure for the `toolboxes` section on the data science extensions website. The changes ensure consistency and accuracy in the links provided.

Updates to URLs in documentation:

* [`docs/toolboxes/synthetic-data-generators.md`](diffhunk://#diff-374b10fed52a66e066141fd390c1a988e1a46cd765edf305c6fcde793497f3e0L11-R16): Updated iframe `src` and anchor `href` URLs to point to `/toolboxes/synthetic-data-generators` instead of `/synthetic-data-generators`.
* [`docs/toolboxes/toolbox-pyspark.md`](diffhunk://#diff-8e4869d7ccd1623b8376ac5c51f7b1c130e8172bbac69c667eece75ed9004a96L11-R16): Updated iframe `src` and anchor `href` URLs to point to `/toolboxes/toolbox-pyspark` instead of `/toolbox-pyspark`.
* [`docs/toolboxes/toolbox-python.md`](diffhunk://#diff-973f0d61d945ee685ebdaae95a5a607c48d5871bad6b4d521c5b3a1ca522ad63L11-R16): Updated iframe `src` and anchor `href` URLs to point to `/toolboxes/toolbox-python` instead of `/toolbox-python`.