### PR TITLE
Add documentation page for Docstring Format Checker toolbox

### DIFF
--- a/docs/toolboxes/docstring-format-checker.md
+++ b/docs/toolboxes/docstring-format-checker.md
@@ -1,0 +1,19 @@
+---
+title: Synthetic Data Generators
+subtitle: A CLI tool to check and validate Python docstring formatting and completeness
+icon: material/notebook-edit-outline
+hide:
+    - toc
+---
+
+<div style="position: relative; width: 100%; height: 500px;">
+    <iframe
+        src="https://www.data-science-extensions.com/toolboxes/docstring-format-checker"
+        style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
+    >
+    </iframe>
+    <a
+        href="https://www.data-science-extensions.com/toolboxes/docstring-format-checker"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; display: block;"
+    ></a>
+</div>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -130,6 +130,7 @@ nav:
       - Python Toolbox: toolboxes/toolbox-python.md
       - PySpark Toolbox: toolboxes/toolbox-pyspark.md
       - Synthetic Data Generators: toolboxes/synthetic-data-generators.md
+      - Docstring Format Checker: toolboxes/docstring-format-checker.md
   - Guides:
       - guides/index.md
       - Querying Data: guides/querying-data/index.md


### PR DESCRIPTION
This pull request adds documentation and navigation for a new "Docstring Format Checker" tool. The main changes introduce a new documentation page that embeds the tool and updates the navigation to include it.

**Documentation and navigation updates:**

* Added a new documentation page `toolboxes/docstring-format-checker.md` with an embedded iframe for the Docstring Format Checker tool.
* Updated the navigation in `mkdocs.yaml` to include the Docstring Format Checker under the Toolboxes section.
* Create new documentation page showcasing the docstring format checker CLI tool
* Embed interactive iframe demonstrating the tool's functionality for validating Python docstring formatting
* Update navigation structure to include the new toolbox in the documentation menu
* Provide users with direct access to explore docstring validation capabilities through the embedded interface