### PR TITLE
Add documentation page for Time Series Statistical Tests

### DIFF
--- a/docs/toolboxes/ts-stat-tests.md
+++ b/docs/toolboxes/ts-stat-tests.md
@@ -1,0 +1,19 @@
+---
+title: Time Series Statistical Tests
+subtitle: A Python library for performing statistical tests on time series data
+icon: material/checkbox-marked-circle-plus-outline
+hide:
+    - toc
+---
+
+<div style="position: relative; width: 100%; height: 500px;">
+    <iframe
+        src="https://www.data-science-extensions.com/toolboxes/ts-stat-tests"
+        style="zoom: 90%; width: 100%; height: 100%; overflow: hidden !important; pointer-events: none !important;"
+    >
+    </iframe>
+    <a
+        href="https://www.data-science-extensions.com/toolboxes/ts-stat-tests"
+        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; display: block;"
+    ></a>
+</div>


### PR DESCRIPTION
This pull request adds new documentation for the Time Series Statistical Tests toolbox. The documentation includes an embedded interactive iframe and a direct link to the toolbox page.

Documentation additions:

* Added a new markdown file `docs/toolboxes/ts-stat-tests.md` with metadata, an embedded iframe preview of the toolbox, and a clickable overlay link to the external toolbox site.