### PR TITLE
Add `ts-stat-tests` page to `mkdocs` config

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -131,6 +131,7 @@ nav:
       - PySpark Toolbox: toolboxes/toolbox-pyspark.md
       - Synthetic Data Generators: toolboxes/synthetic-data-generators.md
       - Docstring Format Checker: toolboxes/docstring-format-checker.md
+      - Time Series Statistical Tests: toolboxes/ts-stat-tests.md
   - Guides:
       - guides/index.md
       - Querying Data: guides/querying-data/index.md


### PR DESCRIPTION
This pull request adds a new documentation entry for the Time Series Statistical Tests toolbox to the navigation menu. No other changes are included.

- Added "Time Series Statistical Tests" (`toolboxes/ts-stat-tests.md`) to the documentation navigation in `mkdocs.yaml`.